### PR TITLE
Rearranged entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,10 +51,10 @@
                </div>
                <div class="col-md-4 column">
                     <h3>
-                         <i class="fa fa-institution"></i> Location
+                         <i class="fa fa-calendar-o"></i> Registration Deadline
                     </h3>
                     <p>
-                         SteelHacks will be held at on the University of Pittsburgh campus, in Sennott Square (at 210 South Bouquet Street).
+                         March 20th, 2015, 11:59 PM
                     </p>
                </div>
                <div class="col-md-4 column">
@@ -69,18 +69,18 @@
           <div class="row clearfix text-center">
                <div class="col-md-4 column">
                     <h3>
-                         <i class="fa fa-calendar-o"></i> Registration Deadline
-                    </h3>
-                    <p>
-                         March 20th, 2015, 11:59 PM
-                    </p>
-               </div>
-               <div class="col-md-4 column">
-                    <h3>
                          <i class="fa fa-ban"></i> Restrictions
                     </h3>
                     <p>
                          Currently, only local university students will be accepted. In future years, we hope that this can change. Additionally, only 150 people total can be registered for this year's SteelHacks.
+                    </p>
+               </div>
+               <div class="col-md-4 column">
+                    <h3>
+                         <i class="fa fa-institution"></i> Location
+                    </h3>
+                    <p>
+                         SteelHacks will be held at on the University of Pittsburgh campus, in Sennott Square (at 210 South Bouquet Street).
                     </p>
                </div>
                <div class="col-md-4 column">


### PR DESCRIPTION
"Registration" feels like it should go right under the registration button. And then for sparse content, location goes right down beneat it.